### PR TITLE
Added "How to Install" section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ Commotion — is a Blender addon for motion graphics, made specifically for easy
 
 #### Demo: http://youtu.be/gLj4PvHbm4s
 #### Tutorial: http://youtu.be/qbJMTOUdxRY
+
+
+How to Install
+========================
+
+- Download this project as a ZIP
+- [Install in Blender User Preferences][1]
+
+[1]:http://wiki.blender.org/index.php/Doc:2.6/Manual/Extensions/Python/Add-Ons


### PR DESCRIPTION
By default, I accidentally extracted the zip and tried to install the py files manually. This will prevent people from doing that in the future.
